### PR TITLE
Add public request method and getmempoolinfo to the api

### DIFF
--- a/gbitcoin/bitcoind.go
+++ b/gbitcoin/bitcoind.go
@@ -95,6 +95,11 @@ func (b *Bitcoin) StartUp(host, bitcoinDir string, port uint) error {
 	}
 }
 
+// Request takes a raw request and issues an RPC call to bitcoind.
+func (b *Bitcoin) Request(m jrpc2.Method, resp interface{}) error {
+	return b.request(m, resp)
+}
+
 // Blocking!
 func (b *Bitcoin) request(m jrpc2.Method, resp interface{}) error {
 

--- a/gbitcoin/bitcoind.go
+++ b/gbitcoin/bitcoind.go
@@ -288,6 +288,29 @@ func (b *Bitcoin) GetRawBlock(blockhash string) (string, error) {
 	return result, err
 }
 
+type MempoolInfo struct {
+	Loaded           bool    `json:"loaded"`
+	Size             uint32  `json:"size"`
+	Bytes            uint64  `json:"bytes"`
+	Usage            uint32  `json:"usage"`
+	MaxMempool       uint32  `json:"maxmempool"`
+	MempoolMinFee    float64 `json:"mempoolminfee"`
+	MinRelayTxFee    float64 `json:"minrelaytxfee"`
+	UnbroadcastCount uint32  `json:"unbroadcastcount"`
+}
+
+type GetMempoolInfoReq struct{}
+
+func (r *GetMempoolInfoReq) Name() string {
+	return "getmempoolinfo"
+}
+
+func (b *Bitcoin) GetMempoolInfo() (*MempoolInfo, error) {
+	var result MempoolInfo
+	err := b.request(&GetMempoolInfoReq{}, &result)
+	return &result, err
+}
+
 type GetRawTransactionReq struct {
 	TxId      string `json:"txid"`
 	Blockhash string `json:"blockhash,omitempty"`


### PR DESCRIPTION
The RPC api is only a subset of the bitcoind RPC api. This Pr adds a public request method that can use an arbitrary `jrpc2.Method` to pass to the bitcoin client.

This Pr also adds `getmempoolinfo` to the api.