### PR TITLE
elements: add blech32 to addrtype

### DIFF
--- a/gelements/elementsd.go
+++ b/gelements/elementsd.go
@@ -101,7 +101,7 @@ func (e *Elements) StartUp(host string, port uint) error {
 // Blocking!
 func (b *Elements) request(m jrpc2.Method, resp interface{}) error {
 	id := b.NextId()
-	mr := &jrpc2.Request{id, m}
+	mr := &jrpc2.Request{Id: id, Method: m}
 	jbytes, err := json.Marshal(mr)
 	if err != nil {
 		return err
@@ -354,10 +354,11 @@ const (
 	Bech32 AddrType = iota
 	P2shSegwit
 	Legacy
+	Blech32
 )
 
 func (a AddrType) String() string {
-	return []string{"bech32", "p2sh-segwit", "legacy"}[a]
+	return []string{"bech32", "p2sh-segwit", "legacy", "blech32"}[a]
 }
 
 func (r *GetNewAddressRequest) Name() string {


### PR DESCRIPTION
The elements getnewaddress rpc was fixed to actually return a bech32 (unblinded) address when requested specifically. This commit adds the (blinded) blech32 type to AddrType.