### PR TITLE
add SetLabel rpc

### DIFF
--- a/gbitcoin/bitcoind.go
+++ b/gbitcoin/bitcoind.go
@@ -654,6 +654,23 @@ func (r *DecodeRawTransactionReq) Name() string {
 	return "decoderawtransaction"
 }
 
+type SetLabelReq struct {
+	Address string `json:"address"`
+	Label   string `json:"label"`
+}
+
+func (r *SetLabelReq) Name() string {
+	return "setlabel"
+}
+
+func (b *Bitcoin) SetLabel(address, label string) error {
+	var result string
+	return b.request(&SetLabelReq{
+		Address: address,
+		Label:   label,
+	}, &result)
+}
+
 type Tx struct {
 	TxId        string      `json:"txid"`
 	Hash        string      `json:"hash"`

--- a/gbitcoin/bitcoind.go
+++ b/gbitcoin/bitcoind.go
@@ -654,23 +654,6 @@ func (r *DecodeRawTransactionReq) Name() string {
 	return "decoderawtransaction"
 }
 
-type SetLabelReq struct {
-	Address string `json:"address"`
-	Label   string `json:"label"`
-}
-
-func (r *SetLabelReq) Name() string {
-	return "setlabel"
-}
-
-func (b *Bitcoin) SetLabel(address, label string) error {
-	var result string
-	return b.request(&SetLabelReq{
-		Address: address,
-		Label:   label,
-	}, &result)
-}
-
 type Tx struct {
 	TxId        string      `json:"txid"`
 	Hash        string      `json:"hash"`

--- a/gelements/elementsd.go
+++ b/gelements/elementsd.go
@@ -765,7 +765,7 @@ type GetBalanceRes struct {
 	BitcoinAmt float64 `json:"bitcoin"`
 }
 
-//GetBalance returns balance in sats
+// GetBalance returns balance in sats
 func (b *Elements) GetBalance() (uint64, error) {
 	var balance GetBalanceRes
 	err := b.request(&GetBalanceRequest{}, &balance)
@@ -897,6 +897,23 @@ func (e *Elements) RawBlindRawTransaction(hex string, inputAmountBlinders []stri
 		IgnoreBlindFail:     true,
 	}, &res)
 	return res, err
+}
+
+type SetLabelReq struct {
+	Address string `json:"address"`
+	Label   string `json:"label"`
+}
+
+func (r *SetLabelReq) Name() string {
+	return "setlabel"
+}
+
+func (e *Elements) SetLabel(address, label string) error {
+	var res string
+	return e.request(&SetLabelReq{
+		Address: address,
+		Label:   label,
+	}, &res)
 }
 
 type PsbtInput struct {


### PR DESCRIPTION
Added SetLabelReq struct and SetLabel method to enable setting labels for addresses in bitcoind and liquid.

related https://github.com/ElementsProject/peerswap/pull/283