### PR TITLE
jrpc: response format for rpc_command hooks

### DIFF
--- a/examples/plugin/pl_example/example.go
+++ b/examples/plugin/pl_example/example.go
@@ -191,7 +191,7 @@ func OnHtlcAccepted(event *glightning.HtlcAcceptedEvent) (*glightning.HtlcAccept
 	return event.Continue(), nil
 }
 
-func OnRpcCommand(event *glightning.RpcCommandEvent) (*glightning.RpcCommandResponse, error) {
+func OnRpcCommand(event *glightning.RpcCommandEvent) (*jrpc2.RpcCommandResponse, error) {
 	cmd := event.Cmd
 	id, _ := cmd.Id()
 	log.Printf("command %s called id %s", cmd.MethodName, id)

--- a/examples/plugin/pl_rpccmd/rpccmd.go
+++ b/examples/plugin/pl_rpccmd/rpccmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/elementsproject/glightning/glightning"
+	"github.com/elementsproject/glightning/jrpc2"
 )
 
 func main() {
@@ -23,7 +24,7 @@ func onInit(plugin *glightning.Plugin, options map[string]glightning.Option, con
 	log.Printf("successfully init'd! %s\n", config.RpcFile)
 }
 
-func OnRpcCommand(event *glightning.RpcCommandEvent) (*glightning.RpcCommandResponse, error) {
+func OnRpcCommand(event *glightning.RpcCommandEvent) (*jrpc2.RpcCommandResponse, error) {
 	cmd := event.Cmd
 	id, _ := cmd.Id()
 	log.Printf("command %s called id %s", cmd.MethodName, id)
@@ -50,7 +51,7 @@ func OnRpcCommand(event *glightning.RpcCommandEvent) (*glightning.RpcCommandResp
 	return event.Continue(), nil
 }
 
-func handleNewAddrRequest(event *glightning.RpcCommandEvent, req *glightning.NewAddrRequest) (*glightning.RpcCommandResponse, error) {
+func handleNewAddrRequest(event *glightning.RpcCommandEvent, req *glightning.NewAddrRequest) (*jrpc2.RpcCommandResponse, error) {
 	// alway set address type to bech32
 	req.AddressType = "bech32"
 

--- a/jrpc2/jsonrpc2.go
+++ b/jrpc2/jsonrpc2.go
@@ -105,6 +105,7 @@ type Response struct {
 	Result Result    `json:"result,omitempty"`
 	Error  *RpcError `json:"error,omitempty"`
 	Id     *Id       `json:"id"`
+	RpcCommandResponse
 }
 
 // RawResponses are what the client gets back
@@ -119,6 +120,17 @@ type RawResponse struct {
 }
 
 type Result interface{}
+
+// the result can be any of the following. providing more than
+// one's behavior is undefined. the API around this should protect you
+// from that, however
+type RpcCommandResponse struct {
+	// deprecated in v0.8.1
+	Continue   *bool           `json:"continue,omitempty"`
+	Result     string          `json:"result,omitempty"`
+	ReplaceObj *Request        `json:"replace,omitempty"`
+	ReturnObj  json.RawMessage `json:"return,omitempty"`
+}
 
 type RpcError struct {
 	Code    int             `json:"code"`


### PR DESCRIPTION
Fix json rpc response format according to
core lightning hook specification.
Previously, the format was nested in `result`,
but the format changes for hooks.

```sh
{"jsonrpc":"2.0","result":{"return":{"result":"xxx"}},"id":"aloha"}
{"jsonrpc":"2.0","id":"aloha","return":{"result":"xxx"}}
 ```