### PR TITLE
glightning: added support for omitempty tag for fields in json

### DIFF
--- a/jrpc2/jsonrpc2.go
+++ b/jrpc2/jsonrpc2.go
@@ -533,6 +533,9 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 		tmType := reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 		ptrType := fVal.Type()
 
+		// if the pointer itself implements Unmarshaler,
+		// or if the thing it points to does,
+		// then we can use that to unmarshal this value
 		if ptrType.Implements(umType) || reflect.PointerTo(ptrType.Elem()).Implements(umType) {
 			n := reflect.New(ptrType.Elem())
 			data, err := json.Marshal(value)
@@ -546,6 +549,7 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 			return nil
 		}
 
+		// Handle types implementing encoding.TextUnmarshaler by parsing from a string and setting the field.
 		if ptrType.Implements(tmType) || reflect.PointerTo(ptrType.Elem()).Implements(tmType) {
 			s, ok := value.(string)
 			if !ok {
@@ -559,6 +563,8 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 			return nil
 		}
 
+		// For pointer-to-non-struct fields, allocate a new element,
+		// parse into it, then assign the pointer.
 		if fVal.Type().Elem().Kind() != reflect.Struct {
 			n := reflect.New(fVal.Type().Elem())
 			err := innerParse(targetValue, n.Elem(), value)
@@ -578,11 +584,13 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 			// so allocate one with this voodoo-magique
 			fVal.Set(reflect.New(fVal.Type().Elem()))
 		}
+
 		return innerParseNamed(fVal.Elem(), value.(map[string]interface{}))
 	case reflect.Struct:
 		if v.Kind() != reflect.Map {
 			return NewError(nil, InvalidParams, fmt.Sprintf("Types don't match. Expected a map[string]interface{} from the JSON, instead got %s", v.Kind().String()))
 		}
+
 		return innerParseNamed(fVal, value.(map[string]interface{}))
 	case reflect.String:
 		fVal.SetString(fmt.Sprintf("%v", v))

--- a/jrpc2/jsonrpc2.go
+++ b/jrpc2/jsonrpc2.go
@@ -1,6 +1,7 @@
 package jrpc2
 
 import (
+	"encoding"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -312,6 +313,10 @@ func GetNamedParams(target Method) map[string]interface{} {
 }
 
 func isZero(x interface{}) bool {
+	if x == nil {
+		return true
+	}
+
 	return reflect.DeepEqual(x, reflect.Zero(reflect.TypeOf(x)).Interface())
 }
 
@@ -354,10 +359,7 @@ func ParseNamedParams(target Method, params map[string]interface{}) error {
 	targetValue := reflect.Indirect(reflect.ValueOf(target))
 	err := innerParseNamed(targetValue, params)
 	if err != nil {
-		fmt.Println("ERR")
-		fmt.Println(err)
-		fmt.Println(targetValue)
-		fmt.Println(params)
+		return err
 	}
 	return nil
 }
@@ -372,12 +374,16 @@ func innerParseNamed(targetValue reflect.Value, params map[string]interface{}) e
 				continue
 			}
 			fT := tType.Field(i)
-			// check for the json tag match, as well a simple
-			// lower case name match
 			tag, _ := fT.Tag.Lookup("json")
-			name, _ := parseTag(tag)
+
+			name, omit := parseTag(tag)
+
 			if name == key || key == strings.ToLower(fT.Name) {
 				found = true
+				if omit && isZero(value) {
+					break
+				}
+
 				err := innerParse(targetValue, fVal, value)
 				if err != nil {
 					return err
@@ -412,14 +418,12 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 	}
 
 	// json.RawMessage escape hatch
-	var eg json.RawMessage
-	if fVal.Type() == reflect.TypeOf(eg) {
+	if strings.Contains(fVal.Type().String(), "RawMessage") {
 		out, err := json.Marshal(value)
 		if err != nil {
 			return err
 		}
-		jm := json.RawMessage(out)
-		fVal.Set(reflect.ValueOf(jm))
+		fVal.Set(reflect.ValueOf(out).Convert(fVal.Type()))
 		return nil
 	}
 
@@ -474,8 +478,12 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 			return nil
 		}
 
-		av := value.([]interface{})
+		av, ok := value.([]interface{})
+		if !ok {
+			return NewError(nil, InvalidParams, fmt.Sprintf("Expected JSON array for slice field %s, but got %T", fVal.Type().Name(), value))
+		}
 		fVal.Set(reflect.MakeSlice(fVal.Type(), len(av), len(av)))
+
 		for i := range av {
 			err := innerParse(targetValue, fVal.Index(i), av[i])
 			if err != nil {
@@ -518,9 +526,39 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 		}
 	case reflect.Ptr:
 		if v.Kind() == reflect.Invalid {
-			// i'm afraid that's a nil, my dear
 			return nil
 		}
+
+		umType := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+		tmType := reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+		ptrType := fVal.Type()
+
+		if ptrType.Implements(umType) || reflect.PointerTo(ptrType.Elem()).Implements(umType) {
+			n := reflect.New(ptrType.Elem())
+			data, err := json.Marshal(value)
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(data, n.Interface()); err != nil {
+				return err
+			}
+			fVal.Set(n)
+			return nil
+		}
+
+		if ptrType.Implements(tmType) || reflect.PointerTo(ptrType.Elem()).Implements(tmType) {
+			s, ok := value.(string)
+			if !ok {
+				return NewError(nil, InvalidParams, fmt.Sprintf("Expected string input for %s.%s, but got %T", targetValue.Type().Name(), fVal.Type().Name(), value))
+			}
+			n := reflect.New(ptrType.Elem())
+			if err := n.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(s)); err != nil {
+				return err
+			}
+			fVal.Set(n)
+			return nil
+		}
+
 		if fVal.Type().Elem().Kind() != reflect.Struct {
 			n := reflect.New(fVal.Type().Elem())
 			err := innerParse(targetValue, n.Elem(), value)
@@ -530,9 +568,11 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 			fVal.Set(n)
 			return nil
 		}
+
 		if v.Kind() != reflect.Map {
 			return NewError(nil, InvalidParams, fmt.Sprintf("Types don't match. Expected a map[string]interface{} from the JSON, instead got %s", v.Kind().String()))
 		}
+
 		if fVal.IsNil() {
 			// You need a new pointer object thing here
 			// so allocate one with this voodoo-magique

--- a/jrpc2/jsonrpc2.go
+++ b/jrpc2/jsonrpc2.go
@@ -375,7 +375,8 @@ func innerParseNamed(targetValue reflect.Value, params map[string]interface{}) e
 			// check for the json tag match, as well a simple
 			// lower case name match
 			tag, _ := fT.Tag.Lookup("json")
-			if tag == key || key == strings.ToLower(fT.Name) {
+			name, _ := parseTag(tag)
+			if name == key || key == strings.ToLower(fT.Name) {
 				found = true
 				err := innerParse(targetValue, fVal, value)
 				if err != nil {
@@ -518,6 +519,15 @@ func innerParse(targetValue reflect.Value, fVal reflect.Value, value interface{}
 	case reflect.Ptr:
 		if v.Kind() == reflect.Invalid {
 			// i'm afraid that's a nil, my dear
+			return nil
+		}
+		if fVal.Type().Elem().Kind() != reflect.Struct {
+			n := reflect.New(fVal.Type().Elem())
+			err := innerParse(targetValue, n.Elem(), value)
+			if err != nil {
+				return err
+			}
+			fVal.Set(n)
 			return nil
 		}
 		if v.Kind() != reflect.Map {

--- a/jrpc2/jsonrpc2_test.go
+++ b/jrpc2/jsonrpc2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// // This section (below) is for method json marshalling,
+// This section (below) is for method json marshalling,
 // with special emphasis on how the parameters get marshalled
 // and unmarshalled to/from 'Method' objects
 type HelloMethod struct {

--- a/jrpc2/jsonrpc2_test.go
+++ b/jrpc2/jsonrpc2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//// This section (below) is for method json marshalling,
+// // This section (below) is for method json marshalling,
 // with special emphasis on how the parameters get marshalled
 // and unmarshalled to/from 'Method' objects
 type HelloMethod struct {
@@ -652,4 +652,43 @@ func TestServerRegistry(t *testing.T) {
 	assert.Nil(t, err_)
 	err_ = server.Unregister(method)
 	assert.Equal(t, "Method not registered", err_.Error())
+}
+
+type OmitEmptyMethod struct {
+	Required string  `json:"required"`
+	Optional *string `json:"optional,omitempty"`
+	Count    *uint32 `json:"count,omitempty"`
+}
+
+func (m OmitEmptyMethod) New() interface{} {
+	return &OmitEmptyMethod{}
+}
+
+func (m OmitEmptyMethod) Call() (jrpc2.Result, error) {
+	return nil, nil
+}
+
+func (m OmitEmptyMethod) Name() string {
+	return "omit_empty"
+}
+
+func TestParsingOmitEmptyFields(t *testing.T) {
+	requestJson := `{"id":1,"method":"omit_empty","params":{"required":"value","optional":"hello","count":7},"jsonrpc":"2.0"}`
+	s := jrpc2.NewServer()
+	s.Register(&OmitEmptyMethod{})
+
+	var result jrpc2.Request
+	err := s.Unmarshal([]byte(requestJson), &result)
+	assert.Nil(t, err)
+
+	method, ok := result.Method.(*OmitEmptyMethod)
+	assert.True(t, ok)
+	assert.Equal(t, "omit_empty", method.Name())
+	assert.Equal(t, "value", method.Required)
+
+	assert.NotNil(t, method.Optional)
+	assert.Equal(t, "hello", *method.Optional)
+
+	assert.NotNil(t, method.Count)
+	assert.Equal(t, uint32(7), *method.Count)
 }


### PR DESCRIPTION
# What’s changed:
- added support for parsing pointer fields whose underlying types implement json.Unmarshaler or encoding.TextUnmarshaler
- added support for parsing pointer scalar fields like *string, *uint32, and similar non-struct pointer types
- improved named parameter parsing for json tags with options such as omitempty by matching against the parsed tag name instead of the raw tag string